### PR TITLE
database/init以下にあるsqlスクリプトをdb起動時に実行するようにボリュームを割り当て

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -8,6 +8,8 @@ services:
       MYSQL_ROOT_PASSWORD: example
     ports:
       - "3306:3306"
+    volumes:
+      - ./database/init:/docker-entrypoint-initdb.d
   server:
     build:
       context: .


### PR DESCRIPTION
#18 
https://qiita.com/NagaokaKenichi/items/ae037963b33a85df33f5

上の記事を参考にcompose.ymlを修正し、compose upを実行した際にdatabase/init/*.sqlが実行されるようにしました。